### PR TITLE
Make cache file path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ augroup END
 |-----------------------------|---------------------------------------------------------------------------------|----------------------------------------------------|
 | `g:loaded_hoogle`           | Any value deactivates the plugin.                                               |                                                    |
 | `g:hoogle_path`             | Path to hoogle executable.                                                      | `'hoogle'`                                         |
+| `g:hoogle_fzf_cache_file`   | Path to the internal fzf-hoogle cache file.                                     | `'./hoogle_cache.json'`                            |
 | `g:hoogle_fzf_window`       | Change fzf window.<sup>1</sup>                                                  | neovim - `{"window": "call hoogle#floatwindow(32, 132)"}`. vim - `{'down': '50%'}` |
 | `g:hoogle_fzf_header`       | Change fzf window header.                                                       | `'enter - restart with the query  alt-s - open in a browser  alt-x - copy type annotation  alt-c - copy import statement'` |
 | `g:hoogle_fzf_preview`      | Change fzf preview split.                                                       | `'right:60%:wrap'`                                 |

--- a/autoload/hoogle.vim
+++ b/autoload/hoogle.vim
@@ -26,7 +26,7 @@ let s:open_tool = get(g:, 'hoogle_open_link', executable('xdg-open') ? 'xdg-open
 let s:enable_messages = get(g:, 'hoogle_enable_messages', 1)
 let s:hoogle_fzf_dir = expand('<sfile>:h:h')
 let s:preview_handler = s:hoogle_fzf_dir .. '/bin/preview.sh'
-let s:cache_file = s:hoogle_fzf_dir .. '/hoogle_cache.json'
+let s:cache_file = get(g:, 'hoogle_fzf_cache_file', s:hoogle_fzf_dir .. '/hoogle_cache.json')
 
 " ----------------------------------------------------------
 " Hoogle


### PR DESCRIPTION
Closes #9 

It works fine on NixOS now. I added this to my Vim config.

```vim
let g:hoogle_fzf_cache_file = '~/.config/hoogle_cache.json'
```

![proof](https://i.imgur.com/ju5FUwv.png)