### PR TITLE
Use single quotes instead of shellescape for open_tool

### DIFF
--- a/autoload/hoogle.vim
+++ b/autoload/hoogle.vim
@@ -91,7 +91,7 @@ function! s:Handler(bang, lines) abort
       let link = trim(system(printf("jq -r --arg a \"%s\" '. | select(.fzfhquery == \$a) | .url' %s",
                                   \ item,
                                   \ s:cache_file)))
-      call system(s:open_tool .. " " .. shellescape(link, 1))
+      call system(s:open_tool .. " '" .. link .. "'")
       call s:Message('The link was sent to a default browser')
     elseif keypress ==? s:copy_type
       let type = substitute(a:lines[2], '.\{-}\s\ze.*', '', '')


### PR DESCRIPTION
The current way of using `shellescape` breaks for 

Searching for `OptDescr` yields the below URL

https://hackage.haskell.org/package/base/docs/System-Console-GetOpt.html%5C%23t:OptDescr

which the browser interprets as

https://hackage.haskell.org/package/base-4.16.1.0/docs/System-Console-GetOpt.html\#t:OptDescr

which doesn't work.

Putting it inside singlequotes `'` works.